### PR TITLE
fix ScribbleFormMixin.clean_content for unicode content on Django>1.9

### DIFF
--- a/scribbler/forms.py
+++ b/scribbler/forms.py
@@ -34,7 +34,7 @@ class ScribbleFormMixin(object):
                 from django.template import Template
                 # Try to create a Template
                 try:
-                    template = Template(template_string=force_text(origin))
+                    template = Template(template_string=force_text(content), origin=origin)
                 # This is an error with creating the template
                 except Exception as e:
                     self.exc_info = {

--- a/scribbler/tests/test_templatetags.py
+++ b/scribbler/tests/test_templatetags.py
@@ -70,6 +70,16 @@ class RenderScribbleTestCase(ScribblerDataTestCase):
         result = self.render_template_tag(slug='"sidebar"')
         self.assertTrue('<p>Default.</p>' in result)
 
+    def test_unicode_rendering(self):
+        "Render with unicode defaults when no scribbles exist."
+        # On Django>=1.9 ScribbleFormMixin.clean_content directly uses django.template.Template
+        # and also uses force_text that may fail for non-string objects that have __str__ with
+        # unicode output.
+        self.scribble.delete()
+        unicode_default = '<p>\u0422\u0435\u043a\u0441\u0442.</p>'
+        result = self.render_template_tag(slug='"sidebar"', default=unicode_default)
+        self.assertTrue(unicode_default in result)
+
     def test_no_slug_given(self):
         "Slug is required by the tag."
         self.assertRaises(TemplateSyntaxError, self.render_template_tag, slug='')


### PR DESCRIPTION
ScribbleFormMixin.clean content fails on content with non-ascii characters for python2.7.

This happens because force_text is called on instance of Origin class so actual transformation is done with `s = six.text_type(bytes(Origin(content)), encoding, errors)`, so `bytes` are called without specifying encoding. 

Fix is simple: template_string should directly use content instead of using Origin object.

@PetrDlouhy, could you please merge this and publish new version on PyPI (https://pypi.org/project/django-scribbler-django2.0/)? It seems that https://github.com/caktus are not checking Pull requests, so your version is the only way to get package that works on `Django>=2.0`